### PR TITLE
Add RawPublicKey and RawSolanaSignature types

### DIFF
--- a/rpc/ws/logsSubscribe.go
+++ b/rpc/ws/logsSubscribe.go
@@ -38,6 +38,24 @@ type LogResult struct {
 	} `json:"value"`
 }
 
+// LogResultG is a generic version of LogResult that allows for either regular or raw signature types
+type LogResultG[S solana.Signature | solana.RawSolanaSignature, P solana.PublicKey | solana.RawPublicKey] struct {
+	Context struct {
+		Slot uint64
+	} `json:"context"`
+	Value struct {
+		// The transaction signature.
+		Signature S `json:"signature"`
+		// Error if transaction failed, null if transaction succeeded.
+		Err interface{} `json:"err"`
+		// Array of log messages the transaction instructions output
+		// during execution, null if simulation failed before the transaction
+		// was able to execute (for example due to an invalid blockhash
+		// or signature verification failure)
+		Logs []string `json:"logs"`
+	} `json:"value"`
+}
+
 type LogsSubscribeFilterType string
 
 const (
@@ -59,6 +77,20 @@ func (cl *Client) LogsSubscribe(
 	)
 }
 
+// LogsSubscribeG is a generic version of LogsSubscribe that allows for either regular or raw signature/pubkey types
+func LogsSubscribeG[S solana.Signature | solana.RawSolanaSignature, P solana.PublicKey | solana.RawPublicKey](
+	cl *Client,
+	// Filter criteria for the logs to receive results by account type.
+	filter LogsSubscribeFilterType,
+	commitment rpc.CommitmentType, // (optional)
+) (*LogSubscriptionG[S, P], error) {
+	return logsSubscribeG[S, P](
+		cl,
+		filter,
+		commitment,
+	)
+}
+
 // LogsSubscribe subscribes to all transactions that mention the provided Pubkey.
 func (cl *Client) LogsSubscribeMentions(
 	// Subscribe to all transactions that mention the provided Pubkey.
@@ -67,6 +99,26 @@ func (cl *Client) LogsSubscribeMentions(
 	commitment rpc.CommitmentType,
 ) (*LogSubscription, error) {
 	return cl.logsSubscribe(
+		rpc.M{
+			"mentions": []string{mentions.String()},
+		},
+		commitment,
+	)
+}
+
+// LogsSubscribeMentionsG is a generic version of LogsSubscribeMentions that allows for either regular or raw signature/pubkey types
+func LogsSubscribeMentionsG[S solana.Signature | solana.RawSolanaSignature, P interface {
+	solana.PublicKey | solana.RawPublicKey
+	String() string
+}](
+	cl *Client,
+	// Subscribe to all transactions that mention the provided Pubkey.
+	mentions solana.PublicKey,
+	// (optional)
+	commitment rpc.CommitmentType,
+) (*LogSubscriptionG[S, P], error) {
+	return logsSubscribeG[S, P](
+		cl,
 		rpc.M{
 			"mentions": []string{mentions.String()},
 		},
@@ -101,6 +153,38 @@ func (cl *Client) logsSubscribe(
 		return nil, err
 	}
 	return &LogSubscription{
+		sub: genSub,
+	}, nil
+}
+
+// logsSubscribeG is a generic version of logsSubscribe that allows for either regular or raw signature/pubkey types
+func logsSubscribeG[S solana.Signature | solana.RawSolanaSignature, P solana.PublicKey | solana.RawPublicKey](
+	cl *Client,
+	filter interface{},
+	commitment rpc.CommitmentType,
+) (*LogSubscriptionG[S, P], error) {
+
+	params := []interface{}{filter}
+	conf := map[string]interface{}{}
+	if commitment != "" {
+		conf["commitment"] = commitment
+	}
+
+	genSub, err := cl.subscribe(
+		params,
+		conf,
+		"logsSubscribe",
+		"logsUnsubscribe",
+		func(msg []byte) (interface{}, error) {
+			var res LogResultG[S, P]
+			err := decodeResponseFromMessage(msg, &res)
+			return &res, err
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &LogSubscriptionG[S, P]{
 		sub: genSub,
 	}, nil
 }
@@ -141,5 +225,45 @@ func (sw *LogSubscription) Response() <-chan *LogResult {
 }
 
 func (sw *LogSubscription) Unsubscribe() {
+	sw.sub.Unsubscribe()
+}
+
+// LogSubscriptionG is a generic version of LogSubscription that allows for either regular or raw signature/pubkey types
+type LogSubscriptionG[S solana.Signature | solana.RawSolanaSignature, P solana.PublicKey | solana.RawPublicKey] struct {
+	sub *Subscription
+}
+
+func (sw *LogSubscriptionG[S, P]) Recv(ctx context.Context) (*LogResultG[S, P], error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case d, ok := <-sw.sub.stream:
+		if !ok {
+			return nil, ErrSubscriptionClosed
+		}
+		return d.(*LogResultG[S, P]), nil
+	case err := <-sw.sub.err:
+		return nil, err
+	}
+}
+
+func (sw *LogSubscriptionG[S, P]) Err() <-chan error {
+	return sw.sub.err
+}
+
+func (sw *LogSubscriptionG[S, P]) Response() <-chan *LogResultG[S, P] {
+	typedChan := make(chan *LogResultG[S, P], 1)
+	go func(ch chan *LogResultG[S, P]) {
+		// TODO: will this subscription yield more than one result?
+		d, ok := <-sw.sub.stream
+		if !ok {
+			return
+		}
+		ch <- d.(*LogResultG[S, P])
+	}(typedChan)
+	return typedChan
+}
+
+func (sw *LogSubscriptionG[S, P]) Unsubscribe() {
 	sw.sub.Unsubscribe()
 }

--- a/rpc/ws/transactionSignatureSubscribe.go
+++ b/rpc/ws/transactionSignatureSubscribe.go
@@ -33,6 +33,19 @@ type TransactionSignatureResult struct {
 	Slot      uint64           `json:"slot"`
 }
 
+// TransactionSignatureResultG is a generic version of TransactionSignatureResult that allows for either regular or raw signature types
+type TransactionSignatureResultG[S solana.Signature | solana.RawSolanaSignature, P solana.PublicKey | solana.RawPublicKey] struct {
+	Transaction struct {
+		Meta struct {
+			LogMessages       []string               `json:"logMessages"`
+			PreTokenBalances  []rpc.TokenBalanceG[P] `json:"preTokenBalances"`
+			PostTokenBalances []rpc.TokenBalanceG[P] `json:"postTokenBalances"`
+		} `json:"meta"`
+	} `json:"transaction"`
+	Signature S      `json:"signature"`
+	Slot      uint64 `json:"slot"`
+}
+
 // TransactionSignatureSubscribe subscribes to a transaction signature. Only Helius rpc nodes support this method.
 func (cl *Client) TransactionSignatureSubscribe(
 	accountInclude []string,
@@ -74,6 +87,49 @@ func (cl *Client) TransactionSignatureSubscribe(
 	)
 }
 
+// TransactionSignatureSubscribeG is a generic version of TransactionSignatureSubscribe that allows for either regular or raw signature/pubkey types
+func TransactionSignatureSubscribeG[S solana.Signature | solana.RawSolanaSignature, P solana.PublicKey | solana.RawPublicKey](
+	cl *Client,
+	accountInclude []string,
+	accountRequired []string,
+	methodProvider TransactionSubscribeMethodProvider,
+	commitment rpc.CommitmentType,
+) (*TransactionSignatureSubscriptionG[S, P], error) {
+	params := make([]any, 0, 3)
+	param := rpc.M{}
+	switch methodProvider {
+	case TransactionSubscribeMethodProviderHelius:
+		if len(accountInclude) > 0 {
+			param["accountInclude"] = accountInclude
+		}
+		if len(accountRequired) > 0 {
+			param["accountRequired"] = accountRequired
+		}
+	case TransactionSubscribeMethodProviderTriton:
+		accountsParam := rpc.M{}
+		if len(accountInclude) > 0 {
+			accountsParam["include"] = accountInclude
+		}
+		if len(accountRequired) > 0 {
+			accountsParam["required"] = accountRequired
+		}
+		param["accounts"] = accountsParam
+	default:
+		return nil, ErrInvalidParams
+	}
+	if len(param) == 0 {
+		return nil, ErrInvalidParams
+	}
+	param["vote"] = false
+	param["failed"] = false
+	params = append(params, param)
+	return transactionSignatureSubscribeG[S, P](
+		cl,
+		params,
+		commitment,
+	)
+}
+
 func (cl *Client) transactionSignatureSubscribe(
 	params []any,
 	commitment rpc.CommitmentType,
@@ -100,6 +156,38 @@ func (cl *Client) transactionSignatureSubscribe(
 		return nil, err
 	}
 	return &TransactionSignatureSubscription{
+		sub: genSub,
+	}, nil
+}
+
+// transactionSignatureSubscribeG is a generic version of transactionSignatureSubscribe that allows for either regular or raw signature/pubkey types
+func transactionSignatureSubscribeG[S solana.Signature | solana.RawSolanaSignature, P solana.PublicKey | solana.RawPublicKey](
+	cl *Client,
+	params []any,
+	commitment rpc.CommitmentType,
+) (*TransactionSignatureSubscriptionG[S, P], error) {
+	conf := map[string]interface{}{}
+	conf["transactionDetails"] = "full"
+	conf["maxSupportedTransactionVersion"] = 0
+	if commitment != "" {
+		conf["commitment"] = commitment
+	}
+	genSub, err := cl.subscribe(
+		params,
+		conf,
+		"transactionSubscribe",
+		"transactionUnsubscribe",
+		func(msg []byte) (interface{}, error) {
+			var res TransactionSignatureResultG[S, P]
+			err := decodeResponseFromMessage(msg, &res)
+			return &res, err
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	return &TransactionSignatureSubscriptionG[S, P]{
 		sub: genSub,
 	}, nil
 }
@@ -148,5 +236,57 @@ func (sw *TransactionSignatureSubscription) Response() <-chan *TransactionSignat
 }
 
 func (sw *TransactionSignatureSubscription) Unsubscribe() {
+	sw.sub.Unsubscribe()
+}
+
+// TransactionSignatureSubscriptionG is a generic version of TransactionSignatureSubscription that allows for either regular or raw signature/pubkey types
+type TransactionSignatureSubscriptionG[S solana.Signature | solana.RawSolanaSignature, P solana.PublicKey | solana.RawPublicKey] struct {
+	sub *Subscription
+}
+
+func (sw *TransactionSignatureSubscriptionG[S, P]) Recv(ctx context.Context) (*TransactionSignatureResultG[S, P], error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case d, ok := <-sw.sub.stream:
+		if !ok {
+			return nil, ErrSubscriptionClosed
+		}
+		return d.(*TransactionSignatureResultG[S, P]), nil
+	case err := <-sw.sub.err:
+		return nil, err
+	}
+}
+
+func (sw *TransactionSignatureSubscriptionG[S, P]) Err() <-chan error {
+	return sw.sub.err
+}
+
+func (sw *TransactionSignatureSubscriptionG[S, P]) AnyResponse() <-chan any {
+	typedChan := make(chan any, 1)
+	go func(ch chan any) {
+		d, ok := <-sw.sub.stream
+		if !ok {
+			return
+		}
+		ch <- d
+	}(typedChan)
+	return typedChan
+}
+
+func (sw *TransactionSignatureSubscriptionG[S, P]) Response() <-chan *TransactionSignatureResultG[S, P] {
+	typedChan := make(chan *TransactionSignatureResultG[S, P], 1)
+	go func(ch chan *TransactionSignatureResultG[S, P]) {
+		// TODO: will this subscription yield more than one result?
+		d, ok := <-sw.sub.stream
+		if !ok {
+			return
+		}
+		ch <- d.(*TransactionSignatureResultG[S, P])
+	}(typedChan)
+	return typedChan
+}
+
+func (sw *TransactionSignatureSubscriptionG[S, P]) Unsubscribe() {
 	sw.sub.Unsubscribe()
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the Solana SDK by adding support for "raw" types (`RawPublicKey` and `RawSolanaSignature`) to avoid base58 decoding during JSON unmarshaling, improving performance when handling large concurrent responses. It also introduces generic types to support both raw and regular types for various Solana structures and subscriptions, enhancing flexibility and usability.

### Key Changes:

#### 1. Addition of Raw Types for Performance Optimization
* Introduced `RawPublicKey` and `RawSolanaSignature` types to represent raw byte data without base58 decoding during JSON unmarshaling. These types include methods for conversion, comparison, and serialization (`keys.go`, `nativetypes.go`). [[1]](diffhunk://#diff-a0896c3a091e9111074431503f5eb3a62aa117962efd8f4033f905a2c2df356cR334-R460) [[2]](diffhunk://#diff-0d9942b94020fe598a5bd73857ef1a544455c54b6549c952bdadb1c49c4c6374R205-R303)

#### 2. Generic Types for Flexibility
* Added generic versions of existing types and methods, such as `TokenBalanceG`, `LogResultG`, and `TransactionSignatureResultG`, to support both raw and regular types for public keys and signatures. These changes enable developers to choose between raw or decoded types based on their use case (`rpc/types.go`, `rpc/ws/logsSubscribe.go`, `rpc/ws/transactionSignatureSubscribe.go`). [[1]](diffhunk://#diff-064c12cf00b0f549b40fa9dff4231b1d1d3c143a2e47cd051a87f5b04d429949R164-R248) [[2]](diffhunk://#diff-3cd20246f432f584de6772c695b45ab89b09be7a248b1cecca627d164b25daf1R41-R58) [[3]](diffhunk://#diff-10930bf1b5af4f1a5f8d7bd68cb163341b04838cf34e272d6e4db3b3772ac187R36-R48)

#### 3. Generic Subscription Methods
* Implemented generic subscription methods like `LogsSubscribeG` and `TransactionSignatureSubscribeG` to handle both raw and regular types, ensuring compatibility with different data formats (`rpc/ws/logsSubscribe.go`, `rpc/ws/transactionSignatureSubscribe.go`). [[1]](diffhunk://#diff-3cd20246f432f584de6772c695b45ab89b09be7a248b1cecca627d164b25daf1R80-R93) [[2]](diffhunk://#diff-10930bf1b5af4f1a5f8d7bd68cb163341b04838cf34e272d6e4db3b3772ac187R90-R132)

#### 4. Conversion Utilities
* Added utility functions to convert between raw and regular types, such as `RawTokenBalanceToTokenBalance` and `RawTokenBalancesToTokenBalances`, to simplify transitions between formats (`rpc/types.go`).

#### 5. Enhanced Subscription Handling
* Extended subscription handling to support generic types, including methods for receiving responses and unsubscribing from subscriptions (`rpc/ws/logsSubscribe.go`, `rpc/ws/transactionSignatureSubscribe.go`). [[1]](diffhunk://#diff-3cd20246f432f584de6772c695b45ab89b09be7a248b1cecca627d164b25daf1R230-R269) [[2]](diffhunk://#diff-10930bf1b5af4f1a5f8d7bd68cb163341b04838cf34e272d6e4db3b3772ac187R241-R292)